### PR TITLE
Fix getCost parameter name

### DIFF
--- a/docs/PublicApi.md
+++ b/docs/PublicApi.md
@@ -57,8 +57,8 @@ Name | Type | Description  | Notes
  **startLat** | **Number**| Latitude of the starting location | 
  **startLng** | **Number**| Longitude of the starting location | 
  **rideType** | **String**| ID of a ride type | [optional] 
- **endLat** | **Number**| Latitude of the ending location | [optional] 
- **endLng** | **Number**| Longitude of the ending location | [optional] 
+ **destinationLat** | **Number**| Latitude of the destination location | [optional] 
+ **destinationLng** | **Number**| Longitude of the destination location | [optional] 
 
 ### Return type
 


### PR DESCRIPTION
I get a bad request error w/ endLat and endLng. Looks like the proper param names are destinationLat and destinationLng